### PR TITLE
Add v11 compatibility and switch to esmodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Attack Roll Check D&D5e
 
-![Foundry Core Compatible Version](https://img.shields.io/badge/dynamic/json.svg?url=https%3A%2F%2Fraw.githubusercontent.com%2FElfFriend-DnD%2Ffoundryvtt-attack-roll-check-5e%2Fmain%2Fmodule.json&label=Foundry%20Version&query=$.compatibleCoreVersion&colorB=orange)
+![Foundry Core Compatible Version](https://img.shields.io/badge/dynamic/json.svg?url=https%3A%2F%2Fraw.githubusercontent.com%2FElfFriend-DnD%2Ffoundryvtt-attack-roll-check-5e%2Fmain%2Fmodule.json&label=Foundry%20Version&query=$.compatibility.verified&colorB=orange)
 ![Latest Release Download Count](https://img.shields.io/badge/dynamic/json?label=Downloads@latest&query=assets%5B1%5D.download_count&url=https%3A%2F%2Fapi.github.com%2Frepos%2FElfFriend-DnD%2Ffoundryvtt-attack-roll-check-5e%2Freleases%2Flatest)
 ![Forge Installs](https://img.shields.io/badge/dynamic/json?label=Forge%20Installs&query=package.installs&suffix=%25&url=https%3A%2F%2Fforge-vtt.com%2Fapi%2Fbazaar%2Fpackage%2Fattack-roll-check-5e&colorB=4aa94a)
 [![Foundry Hub Endorsements](https://img.shields.io/endpoint?logoColor=white&url=https%3A%2F%2Fwww.foundryvtt-hub.com%2Fwp-json%2Fhubapi%2Fv1%2Fpackage%2Fattack-roll-check-5e%2Fshield%2Fendorsements)](https://www.foundryvtt-hub.com/package/attack-roll-check-5e/)

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "id": "attack-roll-check-5e",
   "title": "Attack Roll Check DnD5e",
   "description": "A module which notifies the GM when an attack roll hits a targeted token.",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "authors": [
     {
       "name": "Andrew Krigline",
@@ -12,7 +12,7 @@
       "patreon": "ElfFriend_DnD"
     }
   ],
-  "scripts": [
+  "esmodules": [
     "./scripts/module.js"
   ],
   "styles": [

--- a/module.json
+++ b/module.json
@@ -3,7 +3,6 @@
   "title": "Attack Roll Check DnD5e",
   "description": "A module which notifies the GM when an attack roll hits a targeted token.",
   "version": "2.0.0",
-  "author": "Andrew Krigline",
   "authors": [
     {
       "name": "Andrew Krigline",
@@ -32,7 +31,8 @@
     }
   ],
   "compatibility": {
-    "minimum": 10
+    "minimum": 10,
+    "verified": 11
   },
   "relationships": {
     "systems": [{


### PR DESCRIPTION
- fix the badge in the readme to read the Foundry version correctly
- a little cleanup of the `module.json`, removing the old `author` and adding `verified`
- switch to load the module using `esmodules` instead of `scripts`